### PR TITLE
Switch to regex matching for HeaderCell

### DIFF
--- a/src/main/java/com/vortexa/refinery/cell/AbstractHeaderCell.kt
+++ b/src/main/java/com/vortexa/refinery/cell/AbstractHeaderCell.kt
@@ -2,7 +2,7 @@ package com.vortexa.refinery.cell
 
 sealed class AbstractHeaderCell(private val patterns: List<String>) {
 
-    fun contains(s: String) = patterns.any { s.trim().lowercase().contains(it.lowercase()) }
+    fun contains(s: String) = patterns.any { it.toRegex(option = RegexOption.IGNORE_CASE).containsMatchIn(s) }
 
     fun inside(values: Set<String>) = values.any { this.contains(it) }
 }


### PR DESCRIPTION
I'm having an issue where multiple columns share sub strings. E.g.

Port Name|Previous Port Name|Next Port Name

Rather than add a load of extra logic to the matching process, I think switching to a regex approach (where I can just use "^Port Name") works well here, I've added case insensitivity for backwards compatibility.